### PR TITLE
Pad functional correction

### DIFF
--- a/src/pad_functional.sv
+++ b/src/pad_functional.sv
@@ -15,7 +15,7 @@ module pad_functional_pd
    input  logic             I,
    output logic             O,
    input  logic             PEN,
-   inout  logic             PAD
+   inout  wire              PAD
 );
 
 /*
@@ -52,7 +52,7 @@ module pad_functional_pu
    input  logic             I,
    output logic             O,
    input  logic             PEN,
-   inout  logic             PAD
+   inout  wire              PAD
 );
 
 /*


### PR DESCRIPTION
input port of pad_functional cannot be of type logic because by definition inout ports have to be able to have multiple drivers (which is forbidden by the logic type).

vcs refuses to compile this situation

