### PR TITLE
Fix `tc_sram` parameter

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -6,6 +6,11 @@ dependencies:
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
 
 sources:
+  - target: func_sim
+    files:
+      # level 0
+      - src/rtl/tc_sram.sv
+
   - target: all(fpga, xilinx)
     files:
       - src/deprecated/cluster_clk_cells_xilinx.sv
@@ -18,7 +23,6 @@ sources:
       - src/deprecated/cluster_clk_cells.sv
       - src/deprecated/pulp_clk_cells.sv
       - src/rtl/tc_clk.sv
-      - src/rtl/tc_sram.sv
 
   - target: not(synthesis)
     files:

--- a/Bender.yml
+++ b/Bender.yml
@@ -6,7 +6,7 @@ dependencies:
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
 
 sources:
-  - target: func_sim
+  - target: rtl
     files:
       # level 0
       - src/rtl/tc_sram.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Added
+-`Bender:` Add target `func_sim` for compiling `rtl/tc_sram`, to prevent overwriting of target specific implementations.
 
 ### Fixed
 - `tc_sram`: Drop string literal from parameter `SimInit` definition as synopsys throws an elaboration error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `tc_sram`: Drop string literal from parameter `SimInit` definition as synopsys throws an elaboration error.
+- `tc_clk:tc_clk_delay`: Add Verilator and synthesis guards.
 
 ## 0.2.0 - 2020-03-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 
+### Fixed
+- `tc_sram`: Drop string literal from parameter `SimInit` definition as synopsys throws an elaboration error.
+
 ## 0.2.0 - 2020-03-18
 ### Added
 - Add `tc_sram` and `tc_sram_xilinx`, with testbench for verifying technology specific implementations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Added
--`Bender:` Add target `func_sim` for compiling `rtl/tc_sram`, to prevent overwriting of target specific implementations.
+-`Bender:` Add `rtl/tc_sram` to target `rtl`, to prevent overwriting of target specific implementations.
 
 ### Fixed
 - `tc_sram`: Drop string literal from parameter `SimInit` definition as synopsys throws an elaboration error.

--- a/scripts/compile_vsim.sh
+++ b/scripts/compile_vsim.sh
@@ -15,6 +15,6 @@
 
 set -e
 
-bender script vsim -t test --vlog-arg="-svinputport=compat" --vlog-arg="-override_timescale 1ns/1ps" > compile.tcl
+bender script vsim -t test -t func_sim --vlog-arg="-svinputport=compat" --vlog-arg="-override_timescale 1ns/1ps" > compile.tcl
 echo 'return 0' >> compile.tcl
 vsim -c -do 'exit -code [source compile.tcl]'

--- a/scripts/compile_vsim.sh
+++ b/scripts/compile_vsim.sh
@@ -15,6 +15,6 @@
 
 set -e
 
-bender script vsim -t test -t func_sim --vlog-arg="-svinputport=compat" --vlog-arg="-override_timescale 1ns/1ps" > compile.tcl
+bender script vsim -t test -t rtl --vlog-arg="-svinputport=compat" --vlog-arg="-override_timescale 1ns/1ps" > compile.tcl
 echo 'return 0' >> compile.tcl
 vsim -c -do 'exit -code [source compile.tcl]'

--- a/src/rtl/tc_clk.sv
+++ b/src/rtl/tc_clk.sv
@@ -83,7 +83,11 @@ module tc_clk_delay #(
   output logic out_o
 );
 
+// pragma translate_off
+`ifndef VERILATOR
   assign #(Delay) out_o = in_i;
+`endif
+// pragma translate_on
 
 endmodule
 `endif

--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -56,7 +56,7 @@ module tc_sram #(
   parameter int unsigned ByteWidth    = 32'd8,    // Width of a data byte
   parameter int unsigned NumPorts     = 32'd2,    // Number of read and write ports
   parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
-  parameter string       SimInit      = "none",   // Simulation initialization
+  parameter              SimInit      = "none",   // Simulation initialization
   parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
   // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
   parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,


### PR DESCRIPTION
Synopsys does not like strings for module parameter types.
* `tc_sram` now uses an enum `sim_init_e` from the new `tc_pkg` for changing the Initialization.
* Add `func_sim` target in bender to explicit compile the `src/rtl/tc_sram` module.
