### PR TITLE
tc_sram_xilinx: Remove unsupported `string` from parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- `tc_sram_xilinx`: Remove unsupported `string` type from `SimInit` parameter.
+
 ## 0.2.1 - 2020-06-23
 ### Added
 -`Bender:` Add `rtl/tc_sram` to target `rtl`, to prevent overwriting of target specific implementations.

--- a/src/fpga/tc_sram_xilinx.sv
+++ b/src/fpga/tc_sram_xilinx.sv
@@ -22,7 +22,7 @@ module tc_sram #(
   parameter int unsigned ByteWidth    = 32'd8,    // Width of a data byte (in bits)
   parameter int unsigned NumPorts     = 32'd2,    // Number of read and write ports
   parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
-  parameter string       SimInit      = "zeros",  // Simulation initialization, fixed to zero here!
+  parameter              SimInit      = "zeros",  // Simulation initialization, fixed to zero here!
   parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
   // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
   parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,


### PR DESCRIPTION
Xilinx say they [will not support the `string` type](https://forums.xilinx.com/t5/Synthesis/Is-there-support-for-string-parameters-in-SystemVerilog/m-p/983247/highlight/true#M31515) and that the [workaround is to remove the `string` type from parameters](https://forums.xilinx.com/t5/Synthesis/Is-there-support-for-string-parameters-in-SystemVerilog/m-p/696495/highlight/true#M18140).

/cc @suehtamacv 