### PR TITLE
IPApproX: Add `tc_sram` to `src_files.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `tc_sram_xilinx`: Remove unsupported `string` type from `SimInit` parameter.
+- `IPApproX:` Add `tc_sram` to `src_files.yml` for proper compilation with IPApproX
 
 ## 0.2.2 - 2020-11-11
 ### Fixed

--- a/src_files.yml
+++ b/src_files.yml
@@ -12,6 +12,7 @@ tech_cells_rtl:
     src/deprecated/pulp_clk_cells.sv,
     src/deprecated/pulp_pwr_cells.sv,
     src/rtl/tc_clk.sv,
+    src/rtl/tc_sram.sv,
     src/tc_pwr.sv,
   ]
 
@@ -31,5 +32,6 @@ tech_cells_fpga:
     src/deprecated/pulp_pwr_cells.sv,
     src/deprecated/pulp_buffer.sv,
     src/fpga/tc_clk_xilinx.sv,
+    src/fpga/tc_sram_xilinx.sv,
     src/tc_pwr.sv,
   ]


### PR DESCRIPTION
To allow for proper compilation with IPApprox dependency management, `tc_sram.sv` and `tc_sram_xilinx.sv` was added to `src_files.yml`