### PR TITLE
Patch Bender file for fpga target.

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -15,14 +15,14 @@ sources:
       # level 0
       - src/rtl/tc_sram.sv
 
-  - target: all(all(fpga, xilinx), not(synthesis))
+  - target: all(all(fpga, xilinx), not(asic))
     files:
       - src/deprecated/cluster_clk_cells_xilinx.sv
       - src/deprecated/pulp_clk_cells_xilinx.sv
       - src/fpga/tc_clk_xilinx.sv
       - src/fpga/tc_sram_xilinx.sv
 
-  - target: all(not(all(fpga, xilinx)), not(synthesis))
+  - target: all(not(all(fpga, xilinx)), not(asic))
     files:
       # Level 0
       - src/rtl/tc_clk.sv

--- a/src/fpga/tc_sram_xilinx.sv
+++ b/src/fpga/tc_sram_xilinx.sv
@@ -168,7 +168,7 @@ module tc_sram #(
 // Validate parameters.
 // pragma translate_off
 `ifndef VERILATOR
-`ifndef TARGET_SYNTHESYS
+`ifndef TARGET_SYNTHESIS
   initial begin: p_assertions
     assert (SimInit == "zeros") else $fatal(1, "The Xilinx `tc_sram` has fixed SimInit: zeros");
     assert ($bits(addr_i)  == NumPorts * AddrWidth) else $fatal(1, "AddrWidth problem on `addr_i`");

--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -167,7 +167,7 @@ module tc_sram #(
 // Validate parameters.
 // pragma translate_off
 `ifndef VERILATOR
-`ifndef TARGET_SYNTHESYS
+`ifndef TARGET_SYNTHESIS
   initial begin: p_assertions
     assert ($bits(addr_i)  == NumPorts * AddrWidth) else $fatal(1, "AddrWidth problem on `addr_i`");
     assert ($bits(wdata_i) == NumPorts * DataWidth) else $fatal(1, "DataWidth problem on `wdata_i`");


### PR DESCRIPTION
Looks like `not(synthesys)` automatically overrides the `fpga` target.
To have the xilinx-specific cells linked by Bender to Vivado, we need
to modify `synthesis` into `asic`.
Fixed typo in sram cells.