### PR TITLE
`tc_sram`: Add implementation key and IO

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -10,6 +10,7 @@ sources:
     files:
       # Level 0
       - src/rtl/tc_sram.sv
+      - src/rtl/tc_sram_impl.sv
 
   - target: all(any(all(not(asic), not(fpga)), tech_cells_generic_include_tc_clk), not(tech_cells_generic_exclude_tc_clk))
     files:
@@ -21,6 +22,7 @@ sources:
       - src/fpga/pad_functional_xilinx.sv
       - src/fpga/tc_clk_xilinx.sv
       - src/fpga/tc_sram_xilinx.sv
+      - src/rtl/tc_sram_impl.sv
 
   - target: all(any(not(synthesis), tech_cells_generic_include_deprecated), not(tech_cells_generic_exclude_deprecated))
     files:

--- a/src/fpga/tc_sram_xilinx.sv
+++ b/src/fpga/tc_sram_xilinx.sv
@@ -25,9 +25,6 @@ module tc_sram #(
   parameter              SimInit      = "zeros",  // Simulation initialization, fixed to zero here!
   parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
   parameter              ImplKey      = "none",   // Reference to specific implementation
-  parameter type         impl_in_t    = logic,    // Type for implementation inputs
-  parameter type         impl_out_t   = logic,    // Type for implementation outputs
-  parameter impl_out_t   ImplOutSim   = 'X,       // Implementation output in simulation
   // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
   parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
   parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
@@ -37,11 +34,6 @@ module tc_sram #(
 ) (
   input  logic                clk_i,      // Clock
   input  logic                rst_ni,     // Asynchronous reset active low
-`ifndef PULP_TC_SRAM_NOIMPL
-  // Implementation-related IO
-  input  impl_in_t             impl_i,
-  output impl_out_t            impl_o,
-`endif
   // input ports
   input  logic  [NumPorts-1:0] req_i,      // request
   input  logic  [NumPorts-1:0] we_i,       // write enable
@@ -51,11 +43,6 @@ module tc_sram #(
   // output ports
   output data_t [NumPorts-1:0] rdata_o     // read data
 );
-
-`ifndef PULP_TC_SRAM_NOIMPL
-  // constant implementation output in behavioral simulation
-  assign impl_o = ImplOutSim;
-`endif
 
   localparam int unsigned DataWidthAligned = ByteWidth * BeWidth;
   localparam int unsigned Size             = NumWords * DataWidthAligned;

--- a/src/fpga/tc_sram_xilinx.sv
+++ b/src/fpga/tc_sram_xilinx.sv
@@ -24,6 +24,10 @@ module tc_sram #(
   parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
   parameter              SimInit      = "zeros",  // Simulation initialization, fixed to zero here!
   parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
+  parameter              ImplKey      = "none",   // Reference to specific implementation
+  parameter type         impl_in_t    = logic,    // Type for implementation inputs
+  parameter type         impl_out_t   = logic,    // Type for implementation outputs
+  parameter impl_out_t   ImplOutSim   = 'X,       // Implementation output in simulation
   // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
   parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
   parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
@@ -33,6 +37,11 @@ module tc_sram #(
 ) (
   input  logic                clk_i,      // Clock
   input  logic                rst_ni,     // Asynchronous reset active low
+`ifndef PULP_TC_SRAM_NOIMPL
+  // Implementation-related IO
+  input  impl_in_t             impl_i,
+  output impl_out_t            impl_o,
+`endif
   // input ports
   input  logic  [NumPorts-1:0] req_i,      // request
   input  logic  [NumPorts-1:0] we_i,       // write enable
@@ -42,6 +51,11 @@ module tc_sram #(
   // output ports
   output data_t [NumPorts-1:0] rdata_o     // read data
 );
+
+`ifndef PULP_TC_SRAM_NOIMPL
+  // constant implementation output in behavioral simulation
+  assign impl_o = ImplOutSim;
+`endif
 
   localparam int unsigned DataWidthAligned = ByteWidth * BeWidth;
   localparam int unsigned Size             = NumWords * DataWidthAligned;

--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -30,6 +30,13 @@
 //                "none":   Each bit gets initialized with 1'bx. (default)
 // - PrintSimCfg: Prints at the beginning of the simulation a `Hello` message with
 //                the instantiated parameters and signal widths.
+// - ImplKey:     Key by which an instance can refer to a specific implementation (e.g. macro).
+//                May be used to look up additional parameters for implementation (e.g. generator,
+//                line width, muxing) in an external reference, such as a configuration file.
+// - impl_in_t:   Implementation-related inputs, such as pseudo-static macro configuration inputs.
+// - impl_out_t:  Implementation-related outputs. To ensure the behavioral accuracy of this model,
+//                these may *not* have any effects at the behavioral abstraction level.
+// - ImplOutSim:  Static output assumed by `impl_out_t` in behavioral simulation.
 //
 // Ports:
 // - `clk_i`:   Clock
@@ -40,6 +47,8 @@
 // - `wdata_i`: Write data, has to be valid on request
 // - `be_i`:    Byte enable, active high
 // - `rdata_o`: Read data, valid `Latency` cycles after a request with `we_i` low.
+// - `impl_i`:  Implementation-related inputs
+// - `impl_o`:  Implementation-related outputs
 //
 // Behaviour:
 // - Address collision:  When Ports are making a write access onto the same address,
@@ -58,6 +67,10 @@ module tc_sram #(
   parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
   parameter              SimInit      = "none",   // Simulation initialization
   parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
+  parameter              ImplKey      = "none",   // Reference to specific implementation
+  parameter type         impl_in_t    = logic,    // Type for implementation inputs
+  parameter type         impl_out_t   = logic,    // Type for implementation outputs
+  parameter impl_out_t   ImplOutSim   = 'X,       // Implementation output in simulation
   // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
   parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
   parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
@@ -67,6 +80,11 @@ module tc_sram #(
 ) (
   input  logic                 clk_i,      // Clock
   input  logic                 rst_ni,     // Asynchronous reset active low
+`ifndef PULP_TC_SRAM_NOIMPL
+  // Implementation-related IO
+  input  impl_in_t             impl_i,
+  output impl_out_t            impl_o,
+`endif
   // input ports
   input  logic  [NumPorts-1:0] req_i,      // request
   input  logic  [NumPorts-1:0] we_i,       // write enable
@@ -76,6 +94,11 @@ module tc_sram #(
   // output ports
   output data_t [NumPorts-1:0] rdata_o     // read data
 );
+
+`ifndef PULP_TC_SRAM_NOIMPL
+  // constant implementation output in behavioral simulation
+  assign impl_o = ImplOutSim;
+`endif
 
   // memory array
   data_t sram [NumWords-1:0];

--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -33,10 +33,6 @@
 // - ImplKey:     Key by which an instance can refer to a specific implementation (e.g. macro).
 //                May be used to look up additional parameters for implementation (e.g. generator,
 //                line width, muxing) in an external reference, such as a configuration file.
-// - impl_in_t:   Implementation-related inputs, such as pseudo-static macro configuration inputs.
-// - impl_out_t:  Implementation-related outputs. To ensure the behavioral accuracy of this model,
-//                these may *not* have any effects at the behavioral abstraction level.
-// - ImplOutSim:  Static output assumed by `impl_out_t` in behavioral simulation.
 //
 // Ports:
 // - `clk_i`:   Clock
@@ -47,8 +43,6 @@
 // - `wdata_i`: Write data, has to be valid on request
 // - `be_i`:    Byte enable, active high
 // - `rdata_o`: Read data, valid `Latency` cycles after a request with `we_i` low.
-// - `impl_i`:  Implementation-related inputs
-// - `impl_o`:  Implementation-related outputs
 //
 // Behaviour:
 // - Address collision:  When Ports are making a write access onto the same address,
@@ -68,9 +62,6 @@ module tc_sram #(
   parameter              SimInit      = "none",   // Simulation initialization
   parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
   parameter              ImplKey      = "none",   // Reference to specific implementation
-  parameter type         impl_in_t    = logic,    // Type for implementation inputs
-  parameter type         impl_out_t   = logic,    // Type for implementation outputs
-  parameter impl_out_t   ImplOutSim   = 'X,       // Implementation output in simulation
   // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
   parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
   parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
@@ -80,11 +71,6 @@ module tc_sram #(
 ) (
   input  logic                 clk_i,      // Clock
   input  logic                 rst_ni,     // Asynchronous reset active low
-`ifndef PULP_TC_SRAM_NOIMPL
-  // Implementation-related IO
-  input  impl_in_t             impl_i,
-  output impl_out_t            impl_o,
-`endif
   // input ports
   input  logic  [NumPorts-1:0] req_i,      // request
   input  logic  [NumPorts-1:0] we_i,       // write enable
@@ -94,11 +80,6 @@ module tc_sram #(
   // output ports
   output data_t [NumPorts-1:0] rdata_o     // read data
 );
-
-`ifndef PULP_TC_SRAM_NOIMPL
-  // constant implementation output in behavioral simulation
-  assign impl_o = ImplOutSim;
-`endif
 
   // memory array
   data_t sram [NumWords-1:0];

--- a/src/rtl/tc_sram_impl.sv
+++ b/src/rtl/tc_sram_impl.sv
@@ -1,0 +1,78 @@
+// Copyright (c) 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+// Description: A wrapper for `tc_sram` with generic ports for implementation-related IOs, which
+//              may be used to connect dynamic control and status signals.  In this model, `impl_i`
+//              is ignored and `impl_o` is statically driven. If you need such IOs in your
+//              implementation, you may substitute this module directly instead of `tc_sram`.
+//
+// Additional parameters:
+// - impl_in_t:   Implementation-related inputs, such as pseudo-static macro configuration inputs.
+// - impl_out_t:  Implementation-related outputs. This model only supports driving static values.
+// - ImplOutSim:  Static output assumed by `impl_out_t` in behavioral simulation.
+//
+// Additional ports:
+// - `impl_i`:  Implementation-related inputs
+// - `impl_o`:  Implementation-related outputs
+
+module tc_sram_impl #(
+  parameter int unsigned NumWords     = 32'd1024, // Number of Words in data array
+  parameter int unsigned DataWidth    = 32'd128,  // Data signal width
+  parameter int unsigned ByteWidth    = 32'd8,    // Width of a data byte
+  parameter int unsigned NumPorts     = 32'd2,    // Number of read and write ports
+  parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
+  parameter              SimInit      = "none",   // Simulation initialization
+  parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
+  parameter              ImplKey      = "none",   // Reference to specific implementation
+  parameter type         impl_in_t    = logic,    // Type for implementation inputs
+  parameter type         impl_out_t   = logic,    // Type for implementation outputs
+  parameter impl_out_t   ImplOutSim   = 'X,       // Implementation output in simulation
+) (
+  input  logic                 clk_i,      // Clock
+  input  logic                 rst_ni,     // Asynchronous reset active low
+  // implementation-related IO
+  input  impl_in_t             impl_i,
+  output impl_out_t            impl_o,
+  // input ports
+  input  logic  [NumPorts-1:0] req_i,      // request
+  input  logic  [NumPorts-1:0] we_i,       // write enable
+  input  addr_t [NumPorts-1:0] addr_i,     // request address
+  input  data_t [NumPorts-1:0] wdata_i,    // write data
+  input  be_t   [NumPorts-1:0] be_i,       // write byte enable
+  // output ports
+  output data_t [NumPorts-1:0] rdata_o     // read data
+);
+
+  // We drive a static value for `impl_o` in behavioral simulation.
+  assign impl_o = ImplOutSim;
+
+  tc_sram #(
+  .NumWords     ( NumWords    ),
+  .DataWidth    ( DataWidth   ),
+  .ByteWidth    ( ByteWidth   ),
+  .NumPorts     ( NumPorts    ),
+  .Latency      ( Latency     ),
+  .SimInit      ( SimInit     ),
+  .PrintSimCfg  ( PrintSimCfg ),
+  .ImplKey      ( ImplKey     )
+  ) i_tc_sram (
+    .clk_i,
+    .rst_ni,
+    .req_i,
+    .we_i,
+    .addr_i,
+    .wdata_i,
+    .be_i,
+    .rdata_o
+  );
+
+endmodule

--- a/src/rtl/tc_sram_impl.sv
+++ b/src/rtl/tc_sram_impl.sv
@@ -36,6 +36,12 @@ module tc_sram_impl #(
   parameter type         impl_in_t    = logic,    // Type for implementation inputs
   parameter type         impl_out_t   = logic,    // Type for implementation outputs
   parameter impl_out_t   ImplOutSim   = 'X,       // Implementation output in simulation
+  // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
+  parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
+  parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
+  parameter type         addr_t    = logic [AddrWidth-1:0],
+  parameter type         data_t    = logic [DataWidth-1:0],
+  parameter type         be_t      = logic [BeWidth-1:0]
 ) (
   input  logic                 clk_i,      // Clock
   input  logic                 rst_ni,     // Asynchronous reset active low


### PR DESCRIPTION
This PR

* Adds a metadata string parameter `ImplKey` to `tc_sram`, which serves as a key to identify a specific memory type. Together with an external description of the desired implementation for each key (e.g. macro type), this enables generating `tc_sram` implementation wrappers without having to identify memories by their parameters like width and depth.
* Adds a wrapper `tc_sram_impl` around `tc_sram` with parametric implementation IO (`impl_i` and `impl_o`). This allows setting pseudo-static implementation-specific inputs (e.g. macro configuration) or reading implementation-specific outputs (e.g. physical sensor feedback, interrupts). Importantly, the behavioral model ignores `impl_i` and drives `impl_o` with a static, parameterizable value.

The addition of `ImplKey` is a first step towards addressing #14.