### PR TITLE
`tc_sram`: Remove `'X` initialization for `SimInit = "none"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- `tc_sram`: Remove `'X` initialization for `SimInit = "none"`
+
 ## 0.2.4 - 2021-02-04
 - Add `deprecated/pulp_clk_cells_xilinx.sv` to `Bender.yml`
 

--- a/scripts/compile_vsim.sh
+++ b/scripts/compile_vsim.sh
@@ -15,6 +15,8 @@
 
 set -e
 
+[ ! -z "$VSIM" ] || VSIM=vsim
+
 bender script vsim -t test -t rtl --vlog-arg="-svinputport=compat" --vlog-arg="-override_timescale 1ns/1ps" > compile.tcl
 echo 'return 0' >> compile.tcl
-vsim -c -do 'exit -code [source compile.tcl]'
+${VSIM} -c -do 'exit -code [source compile.tcl]'

--- a/scripts/run_vsim.sh
+++ b/scripts/run_vsim.sh
@@ -14,7 +14,7 @@
 # Andreas Kurth  <akurth@iis.ee.ethz.ch>
 
 set -e
-ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")/.." && pwd)
 
 [ ! -z "$VSIM" ] || VSIM=vsim
 

--- a/scripts/run_xsim.sh
+++ b/scripts/run_xsim.sh
@@ -13,7 +13,7 @@
 # Wolfgang Roenninger <wroennin@ethz.ch>
 
 set -e
-ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")/.." && pwd)
 
 VIVADO_VER="2018.2"
 

--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -124,8 +124,10 @@ module tc_sram #(
   // write memory array
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      for (int unsigned i = 0; i < NumWords; i++) begin
-        sram[i] <= init_val[i];
+      if (SimInit != "none") begin
+        for (int unsigned i = 0; i < NumWords; i++) begin
+          sram[i] <= init_val[i];
+        end
       end
       for (int i = 0; i < NumPorts; i++) begin
         r_addr_q[i] <= {AddrWidth{1'b0}};


### PR DESCRIPTION
This removes any form of initialization for the sram simulation in case the default "none" is set for SimInit. This allows for memory initialization from a tb by hierarchically accessing the module in an initial block, as is done in [HERO](https://github.com/pulp-platform/hero/blob/277b2749dab88636d701921390e94fe329b64569/hardware/test/pulp_tb.sv#L355-L356), see also https://github.com/pulp-platform/hero/commit/c88efca6c5ba6666e9a949956a3020c2bea962ef. In case this is not done, the default behavior should not change drastically, as the initial value will still be `'X`, however will not be reset on rst_ni. If the current behavior is desired, a value other than "none", "zeros", "ones", or "random" should be set for SimInit.