### PR TITLE
Add optional parameter to tc_clk_gating to flag functional gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Added optional `IS_FUNCTIONAL` flag to `tc_clk_gating` cell to optionally mark them as *not required for functionality*.
+
 ## 0.2.4 - 2021-02-04
 - Add `deprecated/pulp_clk_cells_xilinx.sv` to `Bender.yml`
 

--- a/src/rtl/tc_clk.sv
+++ b/src/rtl/tc_clk.sv
@@ -28,7 +28,14 @@ module tc_clk_buffer (
 endmodule
 
 // Description: Behavioral model of an integrated clock-gating cell (ICG)
-module tc_clk_gating (
+module tc_clk_gating #(
+  /// This paramaeter is a hint for tool/technology specific mappings of this
+  /// tech_cell. It indicates wether this particular clk gate instance is
+  /// required for functional correctness or just instantiated for power
+  /// savings. If IS_FUNCTIONAL == 0, technology specific mappings might
+  /// replace this cell with a feedthrough connection without any gating.
+  parameter bit IS_FUNCTIONAL = 1'b1
+)(
    input  logic clk_i,
    input  logic en_i,
    input  logic test_en_i,


### PR DESCRIPTION
For certain target platforms clock gating cells are not available or should be used very sparsingly (e.g. many FPGAs have very limited amounts of global clock buffer cells available for that purposes). For these cases it is important to distinguish between functional clock gates that are required for functional correctness of the design (e.g. in clock dividers or in peripherals) or if the clock gate is only used for hierarchical clock gating for power saving purposes. For clock gating resource limited targets, the later (non-functional clock gates) can be safely replaced with a simple feedthrough without affecting functionality. 

This PR adds an optional parameter to the tc_clk_gating cell for designer to flag, wether a particular CG instance is functionally required or not. Target specific implementations of the generic tc_clk_gating module might then opt to use dedicated ICGs for functional clock gates while removing the not-strictly required ones.

The default value is 1'b1 which means the clock gate is functional. That way the change is backward compatible because by default we assume, that all tc_clk_gating instances in old designs are functionally required unless someone modifies the instantiations to mark them otherwise.