### PR TITLE
Reduce loop usage in sequential blocks

### DIFF
--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -83,7 +83,7 @@ module tc_sram #(
   addr_t [NumPorts-1:0] r_addr_q;
 
   // SRAM simulation initialization
-  data_t [NumWords-1:0] init_val;
+  data_t init_val[NumWords-1:0];
   initial begin : proc_sram_init
     for (int unsigned i = 0; i < NumWords; i++) begin
       for (int unsigned j = 0; j < DataWidth; j++) begin
@@ -124,9 +124,7 @@ module tc_sram #(
   // write memory array
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      for (int unsigned i = 0; i < NumWords; i++) begin
-        sram[i] <= init_val[i];
-      end
+      sram <= init_val;
       for (int i = 0; i < NumPorts; i++) begin
         r_addr_q[i] <= {AddrWidth{1'b0}};
         // initialize the read output register for each port
@@ -150,9 +148,9 @@ module tc_sram #(
         if (req_i[i]) begin
           if (we_i[i]) begin
             // update value when write is set at clock
-            for (int unsigned j = 0; j < DataWidth; j++) begin
-              if (be_i[i][j/ByteWidth]) begin
-                sram[addr_i[i]][j] <= wdata_i[i][j];
+            for (int unsigned j = 0; j < BeWidth; j++) begin
+              if (be_i[i][j]) begin
+                sram[addr_i[i]][j*ByteWidth+:ByteWidth] <= wdata_i[i][j*ByteWidth+:ByteWidth];
               end
             end
           end else begin

--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -121,45 +121,83 @@ module tc_sram #(
     end
   end
 
-  // write memory array
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      sram <= init_val;
-      for (int i = 0; i < NumPorts; i++) begin
-        r_addr_q[i] <= {AddrWidth{1'b0}};
-        // initialize the read output register for each port
-        if (Latency != 32'd0) begin
-          for (int unsigned j = 0; j < Latency; j++) begin
-            rdata_q[i][j] <= init_val[{AddrWidth{1'b0}}];
-          end
+  // In case simulation initialization is disabled (SimInit == 'none'), don't assign to the sram
+  // content at all. This improves simulation performance in tools like verilator
+  if (SimInit == "none") begin
+    // write memory array without initialization
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        for (int i = 0; i < NumPorts; i++) begin
+          r_addr_q[i] <= {AddrWidth{1'b0}};
         end
-      end
-    end else begin
-      // read value latch happens before new data is written to the sram
-      for (int unsigned i = 0; i < NumPorts; i++) begin
-        if (Latency != 0) begin
-          for (int unsigned j = 0; j < Latency; j++) begin
-            rdata_q[i][j] <= rdata_d[i][j];
-          end
-        end
-      end
-      // there is a request for the SRAM, latch the required register
-      for (int unsigned i = 0; i < NumPorts; i++) begin
-        if (req_i[i]) begin
-          if (we_i[i]) begin
-            // update value when write is set at clock
-            for (int unsigned j = 0; j < BeWidth; j++) begin
-              if (be_i[i][j]) begin
-                sram[addr_i[i]][j*ByteWidth+:ByteWidth] <= wdata_i[i][j*ByteWidth+:ByteWidth];
-              end
+      end else begin
+        // read value latch happens before new data is written to the sram
+        for (int unsigned i = 0; i < NumPorts; i++) begin
+          if (Latency != 0) begin
+            for (int unsigned j = 0; j < Latency; j++) begin
+              rdata_q[i][j] <= rdata_d[i][j];
             end
-          end else begin
-            // otherwise update read address for subsequent non request cycles
-            r_addr_q[i] <= addr_i[i];
           end
-        end // if req_i
-      end // for ports
-    end // if !rst_ni
+        end
+        // there is a request for the SRAM, latch the required register
+        for (int unsigned i = 0; i < NumPorts; i++) begin
+          if (req_i[i]) begin
+            if (we_i[i]) begin
+              // update value when write is set at clock
+              for (int unsigned j = 0; j < BeWidth; j++) begin
+                if (be_i[i][j]) begin
+                  sram[addr_i[i]][j*ByteWidth+:ByteWidth] <= wdata_i[i][j*ByteWidth+:ByteWidth];
+                end
+              end
+            end else begin
+              // otherwise update read address for subsequent non request cycles
+              r_addr_q[i] <= addr_i[i];
+            end
+          end // if req_i
+        end // for ports
+      end // if !rst_ni
+    end
+  end else begin
+    // write memory array
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        sram <= init_val;
+        for (int i = 0; i < NumPorts; i++) begin
+          r_addr_q[i] <= {AddrWidth{1'b0}};
+          // initialize the read output register for each port
+          if (Latency != 32'd0) begin
+            for (int unsigned j = 0; j < Latency; j++) begin
+              rdata_q[i][j] <= init_val[{AddrWidth{1'b0}}];
+            end
+          end
+        end
+      end else begin
+        // read value latch happens before new data is written to the sram
+        for (int unsigned i = 0; i < NumPorts; i++) begin
+          if (Latency != 0) begin
+            for (int unsigned j = 0; j < Latency; j++) begin
+              rdata_q[i][j] <= rdata_d[i][j];
+            end
+          end
+        end
+        // there is a request for the SRAM, latch the required register
+        for (int unsigned i = 0; i < NumPorts; i++) begin
+          if (req_i[i]) begin
+            if (we_i[i]) begin
+              // update value when write is set at clock
+              for (int unsigned j = 0; j < BeWidth; j++) begin
+                if (be_i[i][j]) begin
+                  sram[addr_i[i]][j*ByteWidth+:ByteWidth] <= wdata_i[i][j*ByteWidth+:ByteWidth];
+                end
+              end
+            end else begin
+              // otherwise update read address for subsequent non request cycles
+              r_addr_q[i] <= addr_i[i];
+            end
+          end // if req_i
+        end // for ports
+      end // if !rst_ni
+    end
   end
 
 // Validate parameters.


### PR DESCRIPTION
This is an alternative to #20  which significantly reduces the loop count in the sequential block yet doesn't require the usage of blocking assignments. I verified this solution to work with the latest verilator version for the 2 port, 128 bit WordWidth and 16-bit BE width parametrization of tc_sram. If even wider memories are required the user should increase the `--unroll-count` parameter of Verilator as a work around. 