### PR TITLE
Performance optimization of tc_sram init

### DIFF
--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -86,12 +86,12 @@ module tc_sram #(
   data_t init_val[NumWords-1:0];
   initial begin : proc_sram_init
     for (int unsigned i = 0; i < NumWords; i++) begin
-        case (SimInit)
-          "zeros":  init_val[i] = {DataWidth{1'b0}};
-          "ones":   init_val[i] = {DataWidth{1'b1}};
-          "random": init_val[i] = {DataWidth{$urandom()}};
-          default:  init_val[i] = {DataWidth{1'bx}};
-        endcase
+      case (SimInit)
+        "zeros":  init_val[i] = {DataWidth{1'b0}};
+        "ones":   init_val[i] = {DataWidth{1'b1}};
+        "random": init_val[i] = {DataWidth{$urandom()}};
+        default:  init_val[i] = {DataWidth{1'bx}};
+      endcase
     end
   end
 

--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -86,14 +86,12 @@ module tc_sram #(
   data_t init_val[NumWords-1:0];
   initial begin : proc_sram_init
     for (int unsigned i = 0; i < NumWords; i++) begin
-      for (int unsigned j = 0; j < DataWidth; j++) begin
         case (SimInit)
-          "zeros":  init_val[i][j] = 1'b0;
-          "ones":   init_val[i][j] = 1'b1;
-          "random": init_val[i][j] = $urandom();
-          default:  init_val[i][j] = 1'bx;
+          "zeros":  init_val[i] = {DataWidth{1'b0}};
+          "ones":   init_val[i] = {DataWidth{1'b1}};
+          "random": init_val[i] = {DataWidth{$urandom()}};
+          default:  init_val[i] = {DataWidth{1'bx}};
         endcase
-      end
     end
   end
 


### PR DESCRIPTION
tc_sram init takes too many time. Thsi is a fix. My CVA6 simulation takes 1'25'' with current version, and 31'' with the proposal.