### PR TITLE
Add tc_clk_or2 And Add Warning About tc_clk_mux2 Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `tc_clk_or2`: A new generic tech cell for balanced clock OR-gates.
+- Added warning about misusing `tc_clk_mux2` cells.
 
 ## 0.2.10 - 2022-11-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to get started in your own technology (either an unsupported FPGA or
 
 Clock cells usually are care-fully designed cells which do not exhibit any glitches. Therefore they need to be manually instantiated in ASIC designs. All clock cells can be found in `tc_clk.sv`.
 
-|        Name       |         Description          | Status |       Xilinx       |
+| Name              | Description                  | Status | Xilinx             |
 |-------------------|------------------------------|--------|--------------------|
 | `tc_clk_and2`     | Clock and gate               | active | :white_check_mark: |
 | `tc_clk_buffer`   | Clock buffer                 | active | :white_check_mark: |
@@ -27,6 +27,7 @@ Clock cells usually are care-fully designed cells which do not exhibit any glitc
 | `tc_clk_inverter` | Clock inverter               | active | :white_check_mark: |
 | `tc_clk_mux2`     | Clock Mux with two inputs    | active | :white_check_mark: |
 | `tc_clk_xor2`     | Clock Xor                    | active | :white_check_mark: |
+| `tc_clk_or2`      | Clock Or                     | active | :white_check_mark: |
 | `tc_clk_delay`    | Programmable clock-delay     | active |                    |
 
 ### Memory

--- a/src/fpga/tc_clk_xilinx.sv
+++ b/src/fpga/tc_clk_xilinx.sv
@@ -83,3 +83,14 @@ module tc_clk_xor2 (
 
 endmodule
 
+module tc_clk_or2 (
+  input logic clk0_i,
+  input logic clk1_i,
+  output logic clk_o
+);
+
+  assign clk_o = clk0_i | clk1_i;
+
+endmodule
+
+

--- a/src/rtl/tc_clk.sv
+++ b/src/rtl/tc_clk.sv
@@ -61,6 +61,16 @@ module tc_clk_inverter (
 
 endmodule
 
+// Warning: Typical clock mux cells of a technologies std cell library ARE NOT
+// GLITCH FREE!! The only difference to a regular multiplexer cell is that they
+// feature balanced rise- and fall-times. In other words: SWITCHING FROM ONE
+// CLOCK TO THE OTHER CAN INTRODUCE GLITCHES. ALSO, GLITCHES ON THE SELECT LINE
+// DIRECTLY TRANSLATE TO GLITCHES ON THE OUTPUT CLOCK!! This cell is only
+// intended to be used for quasi-static switching between clocks when one of the
+// clocks is anyway inactive or if the downstream logic remains gated or in
+// reset state during the transition phase. If you need dynamic switching
+// between arbitrary input clocks without introducing glitches, have a look at
+// the clk_mux_glitch_free cell in the pulp-platform/common_cells repository.
 module tc_clk_mux2 (
   input  logic clk0_i,
   input  logic clk1_i,

--- a/src/rtl/tc_clk.sv
+++ b/src/rtl/tc_clk.sv
@@ -82,6 +82,16 @@ module tc_clk_xor2 (
 
 endmodule
 
+module tc_clk_or2 (
+  input logic clk0_i,
+  input logic clk1_i,
+  output logic clk_o
+);
+
+  assign clk_o = clk0_i | clk1_i;
+
+endmodule
+
 `ifndef SYNTHESIS
 module tc_clk_delay #(
   parameter int unsigned Delay = 300ps
@@ -98,5 +108,3 @@ module tc_clk_delay #(
 
 endmodule
 `endif
-
-


### PR DESCRIPTION
This PR adds a new generic clock gate cell (OR-gate) to the `tc_clk.sv` cell family. Furthermore, I added a warning about the limitations of the `tc_clk_mux2` cell in common standard cell libraries. They are not glitch-free and must not be used for dynamic switching between two clocks without any additional precautionary steps.