### PR TITLE
Map tc_clk_gating to FPGA primitive for Xilinx FPGAs

### DIFF
--- a/src/fpga/tc_clk_xilinx.sv
+++ b/src/fpga/tc_clk_xilinx.sv
@@ -29,7 +29,6 @@ module tc_clk_buffer (
 
 endmodule
 
-// Disable clock gating on FPGA as it behaves differently than expected
 module tc_clk_gating #(
   /// This paramaeter is a hint for tool/technology specific mappings of this
   /// tech_cell. It indicates wether this particular clk gate instance is
@@ -44,7 +43,20 @@ module tc_clk_gating #(
    output logic clk_o
 );
 
-  assign clk_o = clk_i;
+  if (IS_FUNCTIONAL) begin : gen_functional
+    BUFGCE #(
+      .CE_TYPE        ( "SYNC"       ),
+      .IS_CE_INVERTED ( 1'b0         ),
+      .IS_I_INVERTED  ( 1'b0         ),
+      .SIM_DEVICE     ( "ULTRASCALE" )
+    ) i_clk_gate (
+      .I  ( clk_i ),
+      .CE ( en_i  ),
+      .O  ( clk_o )
+    );
+  end else begin : gen_non_functional
+    assign clk_o = clk_i;
+  end
 
 endmodule
 

--- a/src/fpga/tc_clk_xilinx.sv
+++ b/src/fpga/tc_clk_xilinx.sv
@@ -10,6 +10,13 @@
 
 // Cells to be used for Xilinx FPGA mappings
 
+// Some primitives require a `SIM_DEVICE` parameter, which can be overwritten
+// with this define. If the specified SIM_DEVICE does not match the target part,
+// a critical warning is generated during FPGA synthesis.
+`ifndef XILINX_SIM_DEVICE
+`define XILINX_SIM_DEVICE "ULTRASCALE"
+`endif
+
 module tc_clk_and2 (
   input  logic clk0_i,
   input  logic clk1_i,
@@ -43,16 +50,15 @@ module tc_clk_gating #(
    output logic clk_o
 );
 
+  localparam string SIM_DEVICE = `XILINX_SIM_DEVICE;
+
   if (IS_FUNCTIONAL) begin : gen_functional
     BUFGCE #(
-      .CE_TYPE        ( "SYNC"       ),
-      .IS_CE_INVERTED ( 1'b0         ),
-      .IS_I_INVERTED  ( 1'b0         ),
-      .SIM_DEVICE     ( "ULTRASCALE" )
+      .SIM_DEVICE ( SIM_DEVICE )
     ) i_clk_gate (
-      .I  ( clk_i ),
-      .CE ( en_i  ),
-      .O  ( clk_o )
+      .I  ( clk_i            ),
+      .CE ( en_i | test_en_i ),
+      .O  ( clk_o            )
     );
   end else begin : gen_non_functional
     assign clk_o = clk_i;


### PR DESCRIPTION
In the current version of the `tech_cells_generic`, the `tc_clk_gating` module for FPGA targets implements the clock gate as a pass-through, thus treating it as always enabled. This breaks designs that make use of functional clock gates.

In this PR, functional clock gates are mapped to the `BUFGCE` (Clock gate with enable) primitive. This primitive is available in all common Xilinx FPGA series:
- [Ultrascale and Ultrascale+](https://docs.amd.com/r/en-US/ug974-vivado-ultrascale-libraries/BUFGCE)
- [7 Series and Zynq 7000](https://docs.amd.com/r/en-US/ug953-vivado-7series-libraries/BUFGCE)
- [Versal Prime](https://docs.amd.com/r/en-US/ug1344-versal-architecture-libraries/BUFGCE)
- [Versal Premium](https://docs.amd.com/r/en-US/ug1485-versal-architecture-premium-series-libraries/BUFGCE)
- [Versal AI Core](https://docs.amd.com/r/en-US/ug1353-versal-architecture-ai-libraries/BUFGCE)
- [Versal AI Edge](https://docs.amd.com/r/en-US/ug1726-versal-architecture-ai-edge2-libraries/BUFGCE)

In order to preserve resource usage, clock gates are only mapped to `BUFGCE` primitives only if they are `FUNCTIONAL==1'b1`. Otherwise, they are implemented as pass-through to use less of the typically limited clocking resouces.