### PR TITLE
tc_sram: Guard simulation-only random init from synthesis

### DIFF
--- a/src/rtl/tc_sram.sv
+++ b/src/rtl/tc_sram.sv
@@ -88,6 +88,11 @@ module tc_sram #(
   addr_t [NumPorts-1:0] r_addr_q;
 
   // SRAM simulation initialization
+  // Keep the `init_val` declaration visible to synthesis.
+  // The random/behavioral initialization is simulation-only and relies on `$urandom`,
+  // which synthesis tools cannot elaborate inside a function body.
+  data_t init_val[NumWords-1:0];
+  // pragma translate_off
   function automatic data_t random_init_word();
     random_init_word = '0;
     for (int unsigned b = 0; b < DataWidth; b += 32) begin
@@ -95,7 +100,6 @@ module tc_sram #(
     end
   endfunction
 
-  data_t init_val[NumWords-1:0];
   initial begin : proc_sram_init
     for (int unsigned i = 0; i < NumWords; i++) begin
       unique case (SimInit)
@@ -106,6 +110,7 @@ module tc_sram #(
       endcase
     end
   end
+  // pragma translate_on
 
   // set the read output if requested
   // The read data at the highest array index is set combinational.


### PR DESCRIPTION
#44 moved the random initialization into the `random_init_word` function, so `$urandom` is now elaborated by synthesis tools. In AXI, when Bender automatically updates `tech_cells_generic` to `v0.2.14`, Synopsys DC fails with VER-110.

This PR moves the `init_val` declaration out so it stays visible as the SRAM reset value, and guards the function and the init process with `pragma translate_off`/`translate_on`. Simulators ignore the pragma, so simulation behavior should be unchanged.

This PR is verified in the AXI CI, with DC elaborating `tc_sram` cleanly again, and the Questasim simulation passed.