### PR TITLE
tc_sram_xilinx: Allow Siminit 'none' for simulation

### DIFF
--- a/src/fpga/tc_sram_xilinx.sv
+++ b/src/fpga/tc_sram_xilinx.sv
@@ -182,7 +182,8 @@ module tc_sram #(
 `ifndef VERILATOR
 `ifndef TARGET_SYNTHESIS
   initial begin: p_assertions
-    assert (SimInit == "zeros") else $fatal(1, "The Xilinx `tc_sram` has fixed SimInit: zeros");
+    assert (SimInit == "zeros" || SimInit == "none") else $fatal(1, "The Xilinx `tc_sram` has fixed SimInit: zeros");
+    if (SimInit == "none") $warning("The Xilinx `tc_sram` %m will be initialized with 0 instead of x.");
     assert ($bits(addr_i)  == NumPorts * AddrWidth) else $fatal(1, "AddrWidth problem on `addr_i`");
     assert ($bits(wdata_i) == NumPorts * DataWidth) else $fatal(1, "DataWidth problem on `wdata_i`");
     assert ($bits(be_i)    == NumPorts * BeWidth)   else $fatal(1, "BeWidth   problem on `be_i`"   );


### PR DESCRIPTION
Currently, only `SimInit ("zero")` is allowed for `tc_sram` for Xilinx FPGAs. If a different `SimInit` is used or `SimInit` is not specified, a fatal error is generated for simulation. This breaks simulation of FPGA designs for many IPs, as `SimInit ("none")` or no parameter specification is a common choice if the memory initialization does not matter.

This PR suggests allowing the default paramter value of `SimInit ("none")`, but still generating a warning that the memory content is different than in non-FPGA simulation (`'0` instead of `'x`).